### PR TITLE
chore: 25.3.0 (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. 
+
+### [25.3.0] (2025-3-11)
+
+
+### Features
+* Introduced support for upgrading WSC installations from previous Carbonio versions
+* Added Notification Push Installation on WSC during the upgrade proccess
+* Implemented Carbonio HA upgrade
+* Added validation to ensure inventory password files reside in the same folder as the inventory file
+* Implemented Consul-side checks for packages (carbonio-catalog, carbonio-storages, carbonio-user-management, carbonio-message-broker) added in previous versions and installed them if missing
+* Added automatic installation of Proxy packages if not already installed
+* Added a check for the presence of the [workStreamServers] group in the inventory
+* Added carbonio-perl-mailtools on syslog server during the upgrade proccess
+
+
+### Bug Fixes
+* Added check if /etc/carbonio exists before saving this
+
+# Changelog
+
+All notable changes to this project will be documented in this file. 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: zxbot
 name: carbonio_upgrade
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 24.12.2
+version: 25.3.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/inventoryname
+++ b/inventoryname
@@ -30,6 +30,9 @@
 [videoServers]
 #hostname public_ip_address=x.y.z.t
 
+[workStreamServers]
+#This is only for a server upgrade if it was installed 
+
 [prometheusServers]
 
 [syslogServer]

--- a/playbooks/carbonio_upgrade.yml
+++ b/playbooks/carbonio_upgrade.yml
@@ -24,6 +24,7 @@
   gather_facts: true
   roles:
      - ../roles/upgrade_carbonio_packages
+     - ../roles/install_new_packages
      - ../roles/post_carbonio_packages_upgrade
 
 # Upgrade all dbsConnectorServers, db bootstrap it's executed only on first
@@ -36,6 +37,15 @@
      - ../roles/install_new_packages
      - ../roles/post_carbonio_packages_upgrade
 
+# Upgrade others applicationServers exept dbsConnectorServers
+- hosts: applicationServers, !dbsConnectorServers 
+  serial: 1
+  order: inventory
+  gather_facts: true
+  roles:
+     - ../roles/upgrade_carbonio_packages
+     - ../roles/post_carbonio_packages_upgrade
+
 # Fix packages
 - hosts: filesServers
   order: inventory
@@ -45,8 +55,26 @@
      - ../roles/install_new_packages
      - ../roles/post_carbonio_packages_upgrade
 
+#Upgrade proxy servers
+- hosts: proxyServers
+  order: inventory
+  gather_facts: true
+  roles:
+     - ../roles/upgrade_carbonio_packages
+     - ../roles/install_new_packages
+     - ../roles/post_carbonio_packages_upgrade
+
+# Upgrade WSC
+- hosts: workStreamServers
+  order: inventory
+  gather_facts: true
+  roles:
+     - ../roles/upgrade_carbonio_packages
+     - ../roles/install_new_packages
+     - ../roles/post_carbonio_packages_upgrade
+
 # Upgrade others VMs except consul servers and db-connectors
-- hosts: all, !serviceDiscoverServers, !masterDirectoryServers, !replicaDirectoryServers, !dbsConnectorServers, !filesServers
+- hosts: all, !serviceDiscoverServers, !masterDirectoryServers, !replicaDirectoryServers, !dbsConnectorServers,!applicationServers, !filesServers, !proxyServers, !workStreamServers
   order: inventory
   gather_facts: true
   roles:

--- a/roles/install_new_packages/tasks/install-carbonio-message-broker.yml
+++ b/roles/install_new_packages/tasks/install-carbonio-message-broker.yml
@@ -3,22 +3,52 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 ---
-  - name: Install Message Broker 24.9 -> 24.12 [Ubuntu]
-    become: true
-    apt: name={{ item }} state=present
-    with_items:
-      - "{{ message_broker_packages }}"
-    when: ansible_os_family == "Debian"  and inventory_hostname in groups["masterDirectoryServers"][0]
-    tags:
-      - install-carbonio-message-broker
-      
-##### RHEL
+- name: Check if Message Broker service is present in Consul
+  become: true
+  shell: >
+    consul catalog services | grep -q {{ item }}
+    && echo installed
+    || echo absent
+  with_items: "{{ message_broker_packages }}"
+  register: check_services
+  changed_when: false
+  when:
+    - inventory_hostname in groups['masterDirectoryServers'][0]
+  tags:
+    - install-carbonio-message-broker
 
-  - name: Install Message Broker 24.9 -> 24.12 [RHEL]
-    become: true
-    yum: name={{ item }} state=present
-    with_items:
-      - "{{ message_broker_packages }}"
-    when: (ansible_os_family == "RedHat" or ansible_os_family == "CentOS") and inventory_hostname in groups["masterDirectoryServers"][0]
-    tags:
-      - install-carbonio-message-broker
+- name: Install Message Broker if absent [Ubuntu]
+  become: true
+  apt:
+    name: "{{ item.item }}"
+    state: present
+  with_items: "{{ check_services.results }}"
+  when:
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups['masterDirectoryServers'][0]
+    - item.stdout == "absent"
+  tags:
+    - install-carbonio-message-broker
+
+- name: Install Message Broker if absent [RHEL]
+  become: true
+  yum:
+    name: "{{ item.item }}"
+    state: present
+  with_items: "{{ check_services.results }}"
+  when:
+    - ansible_os_family in ["RedHat", "CentOS"]
+    - inventory_hostname in groups['masterDirectoryServers'][0]
+    - item.stdout == "absent"
+  tags:
+    - install-carbonio-message-broker
+
+- name: Debug message if Message Broker is already installed
+  debug:
+    msg: "Message Broker is already installed"
+  with_items: "{{ check_services.results }}"
+  when:
+    - inventory_hostname in groups['masterDirectoryServers'][0]
+    - item.stdout == "installed"
+  tags:
+    - install-carbonio-message-broker

--- a/roles/install_new_packages/tasks/install-carbonio-notification-push.yml
+++ b/roles/install_new_packages/tasks/install-carbonio-notification-push.yml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+---
+  - name: Install Notification Push on WSC Server [Ubuntu] 24.12 -> 25.3.0
+    become: true
+    apt: name={{ item }} state=present
+    with_items:
+      - "{{ notification_push_packages }}"
+    when: ansible_os_family == "Debian"  and inventory_hostname in groups["workStreamServers"] 
+    tags:
+      - install-carbonio-notification-push
+
+### RHEL
+  - name: Install Notification Push on WSC Server [RHEL] 24.12 -> 25.3.0
+    become: true
+    yum: name={{ item }} state=present
+    with_items:
+      - "{{ notification_push_packages }}"
+    when: (ansible_os_family == "RedHat" or ansible_os_family == "CentOS") and inventory_hostname in groups["workStreamServers"] 
+    tags:
+      - install-carbonio-notification-push

--- a/roles/install_new_packages/tasks/install-carbonio-storages.yml
+++ b/roles/install_new_packages/tasks/install-carbonio-storages.yml
@@ -3,21 +3,21 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 ---
-- name: Check if carbonio-catalog is present in Consul
+- name: Check if carbonio-storages service is present in Consul
   become: true
   shell: >
     consul catalog services | grep -q {{ item }}
     && echo installed
     || echo absent
-  with_items: "{{ catalog_packages }}"
+  with_items: "{{ carbonio_storages_packages }}"
   register: check_services
   changed_when: false
   when:
-    - inventory_hostname in groups['proxyServers']
+    - inventory_hostname in groups['filesServers']
   tags:
-    - install-carbonio-catalog
+    - install-carbonio-storages
 
-- name: Install carbonio-catalog if not found in Consul [Ubuntu]
+- name: Install carbonio-storages if not found in Consul [Ubuntu]
   become: true
   apt:
     name: "{{ item.item }}"
@@ -25,12 +25,12 @@
   with_items: "{{ check_services.results }}"
   when:
     - ansible_os_family == "Debian"
-    - inventory_hostname in groups['proxyServers']
+    - inventory_hostname in groups['filesServers']
     - item.stdout == "absent"
   tags:
-    - install-carbonio-catalog
+    - install-carbonio-storages
 
-- name: Install carbonio-catalog if not found in Consul [RHEL]
+- name: Install carbonio-storages if not found in Consul [RHEL]
   become: true
   yum:
     name: "{{ item.item }}"
@@ -38,17 +38,17 @@
   with_items: "{{ check_services.results }}"
   when:
     - ansible_os_family in ["RedHat", "CentOS"]
-    - inventory_hostname in groups['proxyServers']
+    - inventory_hostname in groups['filesServers']
     - item.stdout == "absent"
   tags:
-    - install-carbonio-catalog
+    - install-carbonio-storages
 
-- name: Debug message for already installed carbonio-catalog
+- name: Debug message for already installed carbonio-storages
   debug:
-    msg: "carbonio-catalog is already installed"
+    msg: "carbonio-storages is already installed"
   with_items: "{{ check_services.results }}"
   when:
-    - inventory_hostname in groups['proxyServers']
+    - inventory_hostname in groups['filesServers']
     - item.stdout == "installed"
   tags:
-    - install-carbonio-catalog
+    - install-carbonio-storages

--- a/roles/install_new_packages/tasks/install-carbonio-user-management.yml
+++ b/roles/install_new_packages/tasks/install-carbonio-user-management.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+---
+- name: Check if carbonio user management service is present in Consul
+  become: true
+  shell: >
+    consul catalog services | grep -q {{ item }}
+    && echo installed
+    || echo absent
+  with_items: "{{ carbonio_user_management_packages }}"
+  register: check_services
+  changed_when: false
+  when:
+    - inventory_hostname in groups['serviceDiscoverServers']
+    - groups['filesServers'] | length > 0
+  tags:
+    - install-carbonio-user-management
+
+- name: Install carbonio user management if not found in Consul [Ubuntu]
+  become: true
+  apt:
+    name: "{{ item.item }}"
+    state: present
+  with_items: "{{ check_services.results }}"
+  when:
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups['serviceDiscoverServers']
+    - groups['filesServers'] | length > 0
+    - item.stdout == "absent"
+  tags:
+    - install-carbonio-user-management
+
+- name: Install carbonio user management if not found in Consul [RHEL]
+  become: true
+  yum:
+    name: "{{ item.item }}"
+    state: present
+  with_items: "{{ check_services.results }}"
+  when:
+    - ansible_os_family in ["RedHat", "CentOS"]
+    - inventory_hostname in groups['serviceDiscoverServers']
+    - groups['filesServers'] | length > 0
+    - item.stdout == "absent"
+  tags:
+    - install-carbonio-user-management
+
+- name: Debug message for already installed carbonio user management
+  debug:
+    msg: "carbonio user management is already installed"
+  with_items: "{{ check_services.results }}"
+  when:
+    - inventory_hostname in groups['serviceDiscoverServers']
+    - groups['filesServers'] | length > 0
+    - item.stdout == "installed"
+  tags:
+    - install-carbonio-user-management

--- a/roles/install_new_packages/tasks/install-db-connectors.yml
+++ b/roles/install_new_packages/tasks/install-db-connectors.yml
@@ -3,102 +3,117 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 ---
-- name: Check if patroni is installed (Debian) 24.9 -> 24.12
+- name: Check if patroni is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^patroni'
   register: patroni_check_debian
   failed_when: false
   changed_when: false 
-  when: inventory_hostname in groups["postgresServers"][0] and ansible_os_family == "Debian"
+  when: inventory_hostname in groups["postgresServers"][0] and ansible_os_family == "Debian"  and groups['dbsConnectorServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
 
-- name: Check if pgpool is installed Ubuntu 24.9 -> 24.12
+- name: Check if pgpool is installed Ubuntu 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^pgpool2'
   register: pgpool_check_debian
   failed_when: false
   changed_when: false 
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian"  and groups['dbsConnectorServers'] | length > 0
   delegate_to: "{{ groups['dbsConnectorServers'][0] }}"
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install mailbox db connector Ubuntu 24.9 -> 24.12
+- name: Install mailbox db connector Ubuntu 24.9 -> 25.3.0
   become: true
   apt: name={{ item }} state=present
   with_items:
     - "{{ mailbox_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0]  
+    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
   tags:
     - install-carbonio-dbconnectors
     
-- name: Install files db connector Ubuntu 24.9 -> 24.12
+- name: Install files db connector Ubuntu 24.9 -> 25.3.0
   become: true
   apt: name={{ item }} state=present
   with_items:
     - "{{ files_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0]
+    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
     
-- name: Install docs db connector Ubuntu 24.9 -> 24.12
+- name: Install docs db connector Ubuntu 24.9 -> 25.3.0
   become: true
   apt: name={{ item }} state=present
   with_items:
     - "{{ docs_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0]
+    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['docsServers'] | length > 0 
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install tasks db connector Ubuntu 24.9 -> 24.12
+- name: Install tasks db connector Ubuntu 24.9 -> 25.3.0
   become: true
   apt: name={{ item }} state=present
   with_items:
     - "{{ task_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['taskServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
 
+- name: Install notification push db connector Ubuntu 24.12 -> 25.3.0
+  become: true
+  apt: name={{ item }} state=present
+  with_items:
+    - "{{ notification_push_dbconnectors_packages }}"
+  when: 
+    - ansible_os_family == "Debian"
+    - (
+        (inventory_hostname in groups['postgresServers'][0] and groups['dbsConnectorServers'] | length == 0) or 
+        (groups['dbsConnectorServers'] | length > 0 and inventory_hostname in groups['dbsConnectorServers'][0] and groups['dbsConnectorServers'][0] != groups['postgresServers'][0])
+      )
+    - groups['workStreamServers'] | length > 0 
+  tags:
+    - install-carbonio-dbconnectors
+
 ##### RHEL
 
-- name: Check if patroni is installed [RHEL] 24.9 -> 24.12
+- name: Check if patroni is installed [RHEL] 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^patroni'
   register: patroni_check_rhel
   failed_when: false 
   changed_when: false
-  when: ansible_os_family == "RedHat" and inventory_hostname in groups["postgresServers"][0]
+  when: ansible_os_family == "RedHat" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
 
-- name: Check if pgpool is installed (RHEL) 24.9 -> 24.12
+- name: Check if pgpool is installed (RHEL) 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^pgpool-II'
   register: pgpool_check_rhel
   failed_when: false 
   changed_when: false
   delegate_to: "{{ groups['dbsConnectorServers'][0] }}"
-  when: ansible_os_family == "RedHat" 
+  when: ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install mailbox db connector RHEL 24.9 -> 24.12
+- name: Install mailbox db connector RHEL 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -106,14 +121,14 @@
   with_items:
     - "{{ mailbox_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" 
+    - ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups["postgresServers"][0] 
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install files db connector RHEL 24.9 -> 24.12
+- name: Install files db connector RHEL 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -121,14 +136,14 @@
   with_items:
     - "{{ files_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups["postgresServers"][0]
+    - ansible_os_family == "RedHat" and inventory_hostname in groups["postgresServers"][0] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install docs db connector RHEL 24.9 -> 24.12
+- name: Install docs db connector RHEL 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -136,7 +151,7 @@
   with_items:
     - "{{ docs_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" 
+    - ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups["postgresServers"][0]
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
@@ -144,7 +159,7 @@
   tags:
     - install-carbonio-dbconnectors
 
-- name: Install tasks db connector RHEL 24.9 -> 24.12
+- name: Install tasks db connector RHEL 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -152,10 +167,25 @@
   with_items:
     - "{{ task_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat"
+    - ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups["postgresServers"][0]
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['taskServers'] | length > 0
+  tags:
+    - install-carbonio-dbconnectors
+  
+- name: Install notification push db connector RHEL 24.12 -> 25.3.0
+  become: true
+  yum: name={{ item }} state=present
+  with_items:
+    - "{{ notification_push_dbconnectors_packages }}"
+  when: 
+    - ansible_os_family == "RedHat" or ansible_os_family == "CentOS"
+    - (
+        (inventory_hostname in groups['postgresServers'][0] and groups['dbsConnectorServers'] | length == 0) or 
+        (groups['dbsConnectorServers'] | length > 0 and inventory_hostname in groups['dbsConnectorServers'][0] and groups['dbsConnectorServers'][0] != groups['postgresServers'][0])
+      ) 
+    - groups['workStreamServers'] | length > 0 
   tags:
     - install-carbonio-dbconnectors

--- a/roles/install_new_packages/tasks/install-new-proxy-packages.yml
+++ b/roles/install_new_packages/tasks/install-new-proxy-packages.yml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+---
+  - name: Install Carbonio Proxy an UIs 24.3 -> 24.5 [Ubuntu]
+    become: true
+    apt: name={{ item }} state=present
+    with_items:
+      - "{{ proxy_packages }}"        
+    when: ansible_os_family == "Debian"  and inventory_hostname in groups["proxyServers"] 
+    tags:
+      - install-carbonio-proxy 
+  
+
+######## RHEL
+  - name: Install Carbonio Proxy an UIs 24.3 -> 24.5 [RHEL]
+    become: true
+    yum: name={{ item }} state=present
+    with_items:
+      - "{{ proxy_packages }}"        
+    when: (ansible_os_family == "RedHat" or ansible_os_family == "CentOS") and inventory_hostname in groups["proxyServers"] 
+    tags:
+      - install-carbonio-proxy      

--- a/roles/install_new_packages/tasks/main.yml
+++ b/roles/install_new_packages/tasks/main.yml
@@ -5,6 +5,11 @@
 ---
 # tasks file for install_new_packages
 - import_tasks: install-carbonio-message-broker.yml
+- import_tasks: install-new-proxy-packages.yml
+- import_tasks: install-carbonio-storages.yml
+- import_tasks: install-carbonio-user-management.yml
 - import_tasks: install-carbonio-catalog.yml
+- import_tasks: install-carbonio-syslog.yml
+- import_tasks: install-carbonio-notification-push.yml
 - import_tasks: install-db-connectors.yml
 - import_tasks: remove-unneeded-packages.yml

--- a/roles/install_new_packages/tasks/remove-unneeded-packages.yml
+++ b/roles/install_new_packages/tasks/remove-unneeded-packages.yml
@@ -3,86 +3,86 @@
 # SPDX-License-Identifier: GPL-3.0-only
 
 ---
-- name: Check if patroni is installed (Debian) 24.9 -> 24.12
+- name: Check if patroni is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^patroni'
   register: patroni_check_debian
   failed_when: false
   changed_when: false 
-  when: ansible_os_family == "Debian"
+  when: ansible_os_family == "Debian" and groups['dbsConnectorServers'] | length > 0
   delegate_to: "{{ groups['postgresServers'][0] }}"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Check if pgpool is installed (Debian) 24.9 -> 24.12
+- name: Check if pgpool is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^pgpool2'
   register: pgpool_check_debian
   failed_when: false
   changed_when: false 
-  when: ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+  when: ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable pgpool service if installed (Debian) 24.9 -> 24.12
+- name: Disable pgpool service if installed (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: pgpool2
     enabled: false
     state: stopped
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Uninstall pgpool package if installed (Debian) 24.9 -> 24.12
+- name: Uninstall pgpool package if installed (Debian) 24.9 -> 25.3.0
   become: true
   apt:
     name: pgpool2
     state: absent
     purge: true
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Check if carbonio-prometheus-pgpool-exporter is installed (Debian) 24.9 -> 24.12
+- name: Check if carbonio-prometheus-pgpool-exporter is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^carbonio-prometheus-pgpool-exporter' 
   register: pgpool_exporter_check_debian
   failed_when: false 
   changed_when: false
-  when: ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+  when: ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable carbonio-prometheus-pgpool-exporter service if installed (Debian) 24.9 -> 24.12
+- name: Disable carbonio-prometheus-pgpool-exporter service if installed (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: carbonio-prometheus-pgpool-exporter
     enabled: false
     state: stopped
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'carbonio-prometheus-pgpool-exporter' in pgpool_exporter_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Uninstall carbonio-prometheus-pgpool-exporter package if installed (Debian) 24.9 -> 24.12
+- name: Uninstall carbonio-prometheus-pgpool-exporter package if installed (Debian) 24.9 -> 25.3.0
   become: true
   apt:
     name: carbonio-prometheus-pgpool-exporter
     state: absent
     purge: true
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     -  "'carbonio-prometheus-pgpool-exporter' in pgpool_exporter_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable mailbox db connector (Debian) 24.9 -> 24.12
+- name: Disable mailbox db connector (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -91,13 +91,13 @@
   with_items:
     - "{{ mailbox_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove mailbox db connector packages (Debian) 24.9 -> 24.12
+- name: Remove mailbox db connector packages (Debian) 24.9 -> 25.3.0
   become: true
   apt: 
     name: "{{ item }}"
@@ -106,13 +106,13 @@
   with_items:
     - "{{ mailbox_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable files db connector (Debian) 24.9 -> 24.12
+- name: Disable files db connector (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -121,14 +121,14 @@
   with_items:
     - "{{ files_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
     
-- name: Remove files db connector packages (Debian) 24.9 -> 24.12
+- name: Remove files db connector packages (Debian) 24.9 -> 25.3.0
   become: true
   apt: 
     name: "{{ item }}"
@@ -137,14 +137,14 @@
   with_items:
     - "{{ files_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable docs db connector (Debian) 24.9 -> 24.12
+- name: Disable docs db connector (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -153,14 +153,14 @@
   with_items:
     - "{{ docs_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['docsServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove docs db connector packages (Debian) 24.9 -> 24.12
+- name: Remove docs db connector packages (Debian) 24.9 -> 25.3.0
   become: true
   apt: 
     name: "{{ item }}"
@@ -169,14 +169,14 @@
   with_items:
     - "{{ docs_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['docsServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable tasks db connector (Debian) 24.9 -> 24.12
+- name: Disable tasks db connector (Debian) 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -185,14 +185,14 @@
   with_items:
     - "{{ task_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout" 
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['taskServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove tasks db connector packages (Debian) 24.9 -> 24.12
+- name: Remove tasks db connector packages (Debian) 24.9 -> 25.3.0
   become: true
   apt: 
     name: "{{ item }}"
@@ -201,7 +201,7 @@
   with_items:
     - "{{ task_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout" 
     - "'patroni' not in patroni_check_debian.stdout"
     - groups['taskServers'] | length > 0
@@ -213,7 +213,7 @@
   command:
     cmd: find /etc/carbonio/ -type d -name '*-db' -exec rm -r {} +
   when: 
-    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "Debian" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
   tags:
@@ -224,7 +224,7 @@
     cmd: 'systemctl reset-failed'
     executable: /bin/bash
   when: 
-    - ansible_os_family == "Debian"
+    - ansible_os_family == "Debian" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups['dbsConnectorServers'] 
     - "'pgpool2' in pgpool_check_debian.stdout"
     - "'patroni' not in patroni_check_debian.stdout"
@@ -233,95 +233,95 @@
 
 #RHEL
 
-- name: Check if patroni is installed [RHEL] 24.9 -> 24.12
+- name: Check if patroni is installed [RHEL] 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^patroni'
   register: patroni_check_rhel
   failed_when: false 
   changed_when: false
-  when: ansible_os_family == "RedHat"
+  when: ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
   delegate_to: "{{ groups['postgresServers'][0] }}"
   tags:
     - install-carbonio-dbconnectors
 
-- name: Check if pgpool is installed [RHEL] 24.9 -> 24.12
+- name: Check if pgpool is installed [RHEL] 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^pgpool-II'
   register: pgpool_check_rhel
   failed_when: false 
   changed_when: false
-  when: ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+  when: ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable pgpool service if installed [RHEL] 24.9 -> 24.12
+- name: Disable pgpool service if installed [RHEL] 24.9 -> 25.3.0
   become: true
   systemd:
     name: pgpool-II
     enabled: false
     state: stopped
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers'] and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Uninstall pgpool package if installed [RHEL] 24.9 -> 24.12
+- name: Uninstall pgpool package if installed [RHEL] 24.9 -> 25.3.0
   become: true
   yum:
     name: pgpool-II
     state: absent
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove pgpool configuration files [RHEL] 24.9 -> 24.12
+- name: Remove pgpool configuration files [RHEL] 24.9 -> 25.3.0
   become: true
   file:
     path: /etc/pgpool-II
     state: absent
   when: 
-    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Check if carbonio-prometheus-pgpool-exporter is installed [RHEL] 24.9 -> 24.12
+- name: Check if carbonio-prometheus-pgpool-exporter is installed [RHEL] 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^carbonio-prometheus-pgpool-exporter'
   register: pgpool_exporter_check_rhel
   failed_when: false 
   changed_when: false
-  when: ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+  when: ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable carbonio-prometheus-pgpool-exporter service if installed [RHEL] 24.9 -> 24.12 24.9 -> 24.12
+- name: Disable carbonio-prometheus-pgpool-exporter service if installed [RHEL] 24.9 -> 25.3.0 24.9 -> 25.3.0
   become: true
   systemd:
     name: carbonio-prometheus-pgpool-exporter
     enabled: false
     state: stopped
   when: 
-    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'carbonio-prometheus-pgpool-exporter' in pgpool_exporter_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Uninstall carbonio-prometheus-pgpool-exporter package if installed [RHEL] 24.9 -> 24.12
+- name: Uninstall carbonio-prometheus-pgpool-exporter package if installed [RHEL] 24.9 -> 25.3.0
   become: true
   package:
     name: carbonio-prometheus-pgpool-exporter
     state: absent
   when: 
-    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "RedHat"  and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'carbonio-prometheus-pgpool-exporter' in pgpool_exporter_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable mailbox db connector [RHEL] 24.9 -> 24.12
+- name: Disable mailbox db connector [RHEL] 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -330,14 +330,14 @@
   with_items:
     - "{{ mailbox_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
 
-- name: Remove mailbox db connector packages [RHEL] 24.9 -> 24.12
+- name: Remove mailbox db connector packages [RHEL] 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -345,13 +345,13 @@
   with_items:
     - "{{ mailbox_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable files db connector [RHEL] 24.9 -> 24.12
+- name: Disable files db connector [RHEL] 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -360,14 +360,14 @@
   with_items:
     - "{{ files_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove files db connector packages [RHEL] 24.9 -> 24.12
+- name: Remove files db connector packages [RHEL] 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -375,14 +375,14 @@
   with_items:
     - "{{ files_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['filesServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable docs db connector [RHEL] 24.9 -> 24.12
+- name: Disable docs db connector [RHEL] 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -391,14 +391,14 @@
   with_items:
     - "{{ docs_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['docsServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove docs db connector packages [RHEL] 24.9 -> 24.12
+- name: Remove docs db connector packages [RHEL] 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -406,14 +406,14 @@
   with_items:
     - "{{ docs_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['docsServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Disable tasks db connector [RHEL] 24.9 -> 24.12
+- name: Disable tasks db connector [RHEL] 24.9 -> 25.3.0
   become: true
   systemd:
     name: "{{ item }}"
@@ -422,14 +422,14 @@
   with_items:
     - "{{ task_dbconnectors_packages | map('regex_replace', '$', '-sidecar') | list }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['taskServers'] | length > 0
   tags:
     - remove-carbonio-dbconnectors
 
-- name: Remove tasks db connector packages [RHEL] 24.9 -> 24.12
+- name: Remove tasks db connector packages [RHEL] 24.9 -> 25.3.0
   become: true
   yum:
     name: "{{ item }}"
@@ -437,7 +437,7 @@
   with_items:
     - "{{ task_dbconnectors_packages }}"
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
     - groups['taskServers'] | length > 0
@@ -449,7 +449,7 @@
   command:
     cmd: find /etc/carbonio/ -type d -name '*-db' -exec rm -r {} +
   when: 
-    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers'] 
+    - ansible_os_family == "RedHat" and inventory_hostname in groups['dbsConnectorServers']  and groups['dbsConnectorServers'] | length > 0
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"
   tags:
@@ -460,7 +460,7 @@
     cmd: 'systemctl reset-failed'
     executable: /bin/bash
   when: 
-    - ansible_os_family == "RedHat"
+    - ansible_os_family == "RedHat"  and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups['dbsConnectorServers'] 
     - "'pgpool-II' in pgpool_check_rhel.stdout"
     - "'patroni' not in patroni_check_rhel.stdout"

--- a/roles/install_new_packages/vars/main.yml
+++ b/roles/install_new_packages/vars/main.yml
@@ -27,7 +27,13 @@
 
   task_dbconnectors_packages:
     - carbonio-tasks-db
-    
+
+  ws_collaboration_dbconnectors_packages:
+    - carbonio-ws-collaboration-db
+
+  notification_push_dbconnectors_packages:
+    - carbonio-notification-push-db
+
   pgpool_packages_ubuntu: 
     - postgresql-client-16
     - pgpool2    
@@ -59,8 +65,9 @@
     - carbonio-admin-ui
     - carbonio-admin-console-ui
     - carbonio-avdb-updater
-      
+
   preview_packages: 
+    - carbonio-docs-editor
     - carbonio-preview
 
   task_packages:
@@ -75,14 +82,31 @@
   
   task_ui_packages:
       - carbonio-tasks-ui
-  
+
+  ws_ui_packages:
+    - carbonio-ws-collaboration-ui
+
   docs_packages: 
     - carbonio-docs-editor
     - carbonio-docs-connector
   
   videoserver_packages: 
-    - carbonio-videoserver
-    - carbonio-videoserver-recorder
+    - carbonio-videoserver-advanced
+    - carbonio-videorecorder
+
+  workstream_packages:
+    - carbonio-message-dispatcher
+    - carbonio-ws-collaboration
+
+  notification_push_packages:
+    - carbonio-notification-push
+    - carbonio-push-connector
+
+  postgres_clent_package_ubuntu:
+    - postgresql-client-16
+
+  postgres_clent_package_rhel:
+    - postgresql16
     
   sda_packages: 
     - service-discover-agent    
@@ -101,3 +125,4 @@
     
   syslog_packages:
     - carbonio-pflogsumm
+    - carbonio-perl-mailtools

--- a/roles/post_carbonio_packages_upgrade/tasks/execute-dbconnectors-bootstrap.yml
+++ b/roles/post_carbonio_packages_upgrade/tasks/execute-dbconnectors-bootstrap.yml
@@ -5,7 +5,7 @@
 ---
 
 ### Ubuntu 
-- name: Check if patroni is installed (Debian) 24.9 -> 24.12
+- name: Check if patroni is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^patroni'
   register: patroni_check_debian
@@ -21,8 +21,8 @@
   ansible.builtin.set_fact:
       carbonio_postgres_password: "{{ lookup('ansible.builtin.password', inventory_file + '_postgrespassword', chars=['ascii_letters']) }}"
   when: 
-    - ansible_os_family == "Debian"
-    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - ansible_os_family == "Debian" and groups['dbsConnectorServers'] | length > 0
+    - inventory_hostname in groups["dbsConnectorServers"][0] 
     - "'patroni' in patroni_check_debian.stdout"
   tags:
       - db-connectors-bootstrap
@@ -34,8 +34,8 @@
   command: /usr/bin/carbonio-mailbox-db-bootstrap carbonio_adm 127.0.0.1
   become: true
   when: 
-    - ansible_os_family == "Debian"
-    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - ansible_os_family == "Debian" and groups['dbsConnectorServers'] | length > 0
+    - inventory_hostname in groups["dbsConnectorServers"][0] 
     - "'patroni' in patroni_check_debian.stdout"
   tags:
       - db-connectors-bootstrap
@@ -47,7 +47,7 @@
   become: true
   run_once: true
   when: 
-    - groups['filesServers'] | length > 0 
+    - groups['filesServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "Debian"
     - inventory_hostname in groups["dbsConnectorServers"][0]
     - "'patroni' in patroni_check_debian.stdout"
@@ -61,7 +61,7 @@
   run_once: true
   command: /usr/bin/carbonio-docs-connector-db-bootstrap carbonio_adm 127.0.0.1
   when: 
-    - groups['docsServers'] | length > 0 
+    - groups['docsServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "Debian"
     - inventory_hostname in groups["dbsConnectorServers"][0]
     - "'patroni' in patroni_check_debian.stdout"
@@ -75,12 +75,38 @@
   run_once: true
   command: /usr/bin/carbonio-tasks-db-bootstrap carbonio_adm 127.0.0.1
   when:  
-    - groups['taskServers'] | length > 0 
+    - groups['taskServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "Debian"
     - inventory_hostname in groups["dbsConnectorServers"][0]
     - "'patroni' in patroni_check_debian.stdout"
   tags:
       - db-connectors-bootstrap
+
+- name: run carbonio-ws-collaboration-db Bootstrap (HA)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - "'patroni' in patroni_check_debian.stdout"
+  tags:
+    - db-connectors-bootstrap
+
+- name: run carbonio-notification-push-db Bootstrap (HA)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-notification-push-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - "'patroni' in patroni_check_debian.stdout"
+  tags:
+    - db-connectors-bootstrap
 
 # If Partoni is not installd
 - name: Manage Postgres password (Standard)
@@ -148,9 +174,34 @@
   tags:
       - db-connectors-bootstrap
 
-### RHEL
+- name: run carbonio-ws-collaboration-db Bootstrap (Standard)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups["postgresServers"][0]
+    - "'patroni' not in patroni_check_debian.stdout"
+  tags:
+    - db-connectors-bootstrap
 
-- name: Check if patroni is installed [RHEL] 24.9 -> 24.12
+- name: run carbonio-notification-push-db Bootstrap
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-notification-push-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0
+    - ansible_os_family == "Debian"
+    - inventory_hostname in groups["postgresServers"][0]
+    - "'patroni' not in patroni_check_debian.stdout"
+  tags:
+    - db-connectors-bootstrap
+
+### RHEL
+- name: Check if patroni is installed [RHEL] 24.9 -> 25.3.0 (Standard)
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^patroni'
   register: patroni_check_rhel
@@ -166,7 +217,7 @@
   ansible.builtin.set_fact:
       carbonio_postgres_password: "{{ lookup('ansible.builtin.password', inventory_file + '_postgrespassword', chars=['ascii_letters']) }}"
   when: 
-    - ansible_os_family == "RedHat" 
+    - ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups['dbsConnectorServers'][0] 
     - "'patroni' in patroni_check_rhel.stdout"
   tags:
@@ -178,7 +229,7 @@
   command: /usr/bin/carbonio-mailbox-db-bootstrap carbonio_adm 127.0.0.1
   become: true
   when: 
-    - ansible_os_family == "RedHat" 
+    - ansible_os_family == "RedHat" and groups['dbsConnectorServers'] | length > 0
     - inventory_hostname in groups['dbsConnectorServers'][0] 
     - "'patroni' in patroni_check_rhel.stdout"
   tags:
@@ -191,7 +242,7 @@
   become: true
   run_once: true
   when: 
-    - groups['filesServers'] | length > 0 
+    - groups['filesServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "RedHat" 
     - inventory_hostname in groups['dbsConnectorServers'][0] 
     - "'patroni' in patroni_check_rhel.stdout" 
@@ -205,7 +256,7 @@
   run_once: true
   command: /usr/bin/carbonio-docs-connector-db-bootstrap carbonio_adm 127.0.0.1
   when: 
-    - groups['docsServers'] | length > 0 
+    - groups['docsServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "RedHat" 
     - inventory_hostname in groups['dbsConnectorServers'][0] 
     - "'patroni' in patroni_check_rhel.stdout"
@@ -219,12 +270,38 @@
   run_once: true
   command: /usr/bin/carbonio-tasks-db-bootstrap carbonio_adm 127.0.0.1
   when:  
-    - groups['taskServers'] | length > 0 
+    - groups['taskServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
     - ansible_os_family == "RedHat" 
     - inventory_hostname in groups['dbsConnectorServers'][0] 
     - "'patroni' in patroni_check_rhel.stdout"
   tags:
       - db-connectors-bootstrap
+
+- name: run carbonio-ws-collaboration-db Bootstrap (HA)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
+    - ansible_os_family == "RedHat" 
+    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - "'patroni' in patroni_check_rhel.stdout"
+  tags:
+    - db-connectors-bootstrap
+
+- name: run carbonio-notification-push-db Bootstrap (HA)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-notification-push-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0 and groups['dbsConnectorServers'] | length > 0
+    - ansible_os_family == "RedHat" 
+    - inventory_hostname in groups["dbsConnectorServers"][0]
+    - "'patroni' in patroni_check_rhel.stdout"
+  tags:
+    - db-connectors-bootstrap
 
 ### If Patroni is not installed 
 
@@ -291,3 +368,29 @@
     - "'patroni' not in patroni_check_rhel.stdout"
   tags:
       - db-connectors-bootstrap
+
+- name: run carbonio-ws-collaboration-db Bootstrap (Standard)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-ws-collaboration-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0
+    - ansible_os_family == "RedHat" 
+    - inventory_hostname in groups["postgresServers"][0]
+    - "'patroni' not in patroni_check_rhel.stdout"
+  tags:
+    - db-connectors-bootstrap
+
+- name: run carbonio-notification-push-db Bootstrap (Standard)
+  environment:
+    PGPASSWORD: "{{ carbonio_postgres_password }}"
+  become: true
+  command: /usr/bin/carbonio-notification-push-db-bootstrap carbonio_adm 127.0.0.1
+  when: 
+    - groups['workStreamServers'] | length > 0
+    - ansible_os_family == "RedHat" 
+    - inventory_hostname in groups["postgresServers"][0]
+    - "'patroni' not in patroni_check_rhel.stdout"
+  tags:
+    - db-connectors-bootstrap

--- a/roles/post_carbonio_packages_upgrade/tasks/main.yml
+++ b/roles/post_carbonio_packages_upgrade/tasks/main.yml
@@ -4,7 +4,7 @@
 
 ---
 # tasks file for post-carbonio-packages-upgrade
+- import_tasks: remove-unused-dependencies.yml
 - import_tasks: execute-carbonio-pending-setups.yml
 - import_tasks: execute-dbconnectors-bootstrap.yml
-- import_tasks: remove-unused-dependencies.yml
 - import_tasks: restart-carbonio-services.yml

--- a/roles/post_carbonio_packages_upgrade/tasks/restart-carbonio-services.yml
+++ b/roles/post_carbonio_packages_upgrade/tasks/restart-carbonio-services.yml
@@ -10,7 +10,7 @@
 #  5 start service-discover agent, all sidecars, proxyServers
 #  6 start service-discover agent, all sidecars, mtaServers
 
-- name: Check if patroni is installed (Debian) 24.9 -> 24.12
+- name: Check if patroni is installed (Debian) 24.9 -> 25.3.0
   become: true
   shell: apt list --installed 2>/dev/null | grep -w '^patroni'
   register: patroni_check_debian
@@ -51,7 +51,7 @@
     - restart-carbonio-services
     - postgresServers
 
-- name: Check if patroni is installed [RHEL] 24.9 -> 24.12
+- name: Check if patroni is installed [RHEL] 24.9 -> 25.3.0
   become: true
   shell: rpm -qa 2>/dev/null | grep -w '^patroni'
   register: patroni_check_rhel
@@ -300,16 +300,27 @@
     - restart-carbonio-service
     - previewServers
 
-- name: Restart video carbonio services
+- name: Get all videoserver services
+  become: true
+  shell:
+    cmd: "set -o pipefail && systemctl list-unit-files --state=enabled | awk '/videoserver/ {print $1}'"
+    executable: /bin/bash
+  register: videoserver_services_in_memory
+  changed_when: false
+  when: inventory_hostname in groups["videoServers"]
+  tags:
+    - restart-videoserver-services
+    - videoServers
+    
+- name: Restart carbonio videoservers
   become: true
   ansible.builtin.service:
     name: "{{ item }}"
     state: restarted
   when: inventory_hostname in groups["videoServers"]
-  loop:
-    - videoserver.service
+  loop: "{{ videoserver_services_in_memory.stdout_lines }}"
   tags:
-    - restart-carbonio-service
+    - restart-videoserver-services
     - videoServers
 
 # Remove restart file on all VMs

--- a/roles/pre_carbonio_upgrade/tasks/main.yml
+++ b/roles/pre_carbonio_upgrade/tasks/main.yml
@@ -5,4 +5,5 @@
 ---
 # tasks file for pre-carbonio-upgrade
 - import_tasks: password-checks.yml
+- import_tasks: workstreamservers_check.yml
 - import_tasks: pre-upgrade-cmds.yml

--- a/roles/pre_carbonio_upgrade/tasks/pre-upgrade-cmds.yml
+++ b/roles/pre_carbonio_upgrade/tasks/pre-upgrade-cmds.yml
@@ -54,9 +54,17 @@
   tags:
     - pre-upgrade-cmds
 
-- name: Save /etc/carbonio
+- name: Check if /etc/carbonio was created on the server
+  stat:
+    path: /etc/carbonio
+  register: carbonio_dir
+  tags:
+  - pre-upgrade-cmds
+
+- name: Save /etc/carbonio 
   become: true
   become_method: su
-  command: 'rsync  -av /etc/carbonio /bck/{{ ansible_date_time.date }}/etc/'
+  command: "rsync -av /etc/carbonio /bck/{{ ansible_date_time.date }}/etc/"
+  when: carbonio_dir.stat.isdir is defined and carbonio_dir.stat.isdir
   tags:
     - pre-upgrade-cmds

--- a/roles/pre_carbonio_upgrade/tasks/workstreamservers_check.yml
+++ b/roles/pre_carbonio_upgrade/tasks/workstreamservers_check.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+#
+# SPDX-License-Identifier: GPL-3.0-only
+
+---
+- name: Check that the workStreamServers group is defined in the inventory
+  fail:
+    msg: "The inventory file must include the group [workStreamServers]. Starting with version 25.3.0, this group is mandatory. Even if WSC installation is not required, the group must be present (it can be left empty). Please update your inventory file and re-run the installation."
+  when: "'workStreamServers' not in groups"
+  tags:
+  - check-wsc-group

--- a/roles/upgrade_carbonio_packages/tasks/upgrade-carbonio.yml
+++ b/roles/upgrade_carbonio_packages/tasks/upgrade-carbonio.yml
@@ -59,6 +59,91 @@
   debug:
     msg: "{{ pkgr }}"
 
+#carbonio-core version check (Ubuntu)
+- block:
+    - name: Get list of installed packages (Debian/Ubuntu)
+      shell: apt list --installed 2>/dev/null
+      register: apt_installed
+      changed_when: false
+      tags:
+        - upgrade-carbonio
+
+    - name: Set fact with carbonio-core version if installed (Debian/Ubuntu)
+      set_fact:
+        carbonio_core_version: "{{ (apt_installed.stdout | regex_findall('(?m)^carbonio-core/\\S+\\s+(\\S+)'))[0] }}"
+      when:
+        - (apt_installed.stdout_lines | select('match', '^carbonio-core/') | list) | length > 0
+      tags:
+        - upgrade-carbonio
+
+  when:
+    - ansible_os_family == 'Debian'
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+
+#carbonio-core version check (RHEL/Centos)
+- block:
+    - name: Get list of installed packages (RHEL/CentOS)
+      shell: yum list installed 2>/dev/null
+      register: yum_installed
+      changed_when: false
+      tags:
+        - upgrade-carbonio
+
+    - name: Set fact with carbonio-core version if installed (RHEL/CentOS)
+      set_fact:
+        carbonio_core_version: "{{ (yum_installed.stdout | regex_findall('(?m)^carbonio-core\\.\\S+\\s+(\\S+)'))[0] }}"
+      when:
+        - (yum_installed.stdout_lines | select('match', '^carbonio-core\\.') | list) | length > 0
+      tags:
+        - upgrade-carbonio
+
+  when:
+    - ansible_os_family in ["RedHat", "CentOS"]
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+
+#Common tasks
+- name: Display installed carbonio-core version
+  debug:
+    msg: "Installed carbonio-core version: {{ carbonio_core_version | default('Package not installed') }}"
+  when:
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+  tags:
+    - upgrade-carbonio
+
+- name: Restart carbonio services if carbonio-core version is less than 4.2.0
+  become: true
+  become_method: su
+  become_user: zextras
+  command: '/opt/zextras/bin/zmcontrol restart'
+  when:
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+    - carbonio_core_version is defined
+    - carbonio_core_version is version('4.2', '<')
+  tags:
+    - upgrade-carbonio
+
+- name: Wait for 20 seconds for restart
+  ansible.builtin.pause:
+    seconds: 20
+  when:
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+    - carbonio_core_version is defined
+    - carbonio_core_version is version('4.2', '<')
+  tags:
+    - upgrade-carbonio
+
+- name: Stop carbonio services if carbonio-core version is less than 4.2.0
+  become: true
+  become_method: su
+  become_user: zextras
+  command: '/opt/zextras/bin/zmcontrol stop'
+  when:
+    - inventory_hostname in groups['dbsConnectorServers'] or inventory_hostname in groups['applicationServers']
+    - carbonio_core_version is defined
+    - carbonio_core_version is version('4.2', '<')
+  tags:
+    - upgrade-carbonio
+
 - name: Update all packages to their latest version
   ansible.builtin.apt:
     upgrade: full


### PR DESCRIPTION
* fix: remove ldap stopping task (#17)

* chore: 24.12.0 (#19)

* chore: merge rc to devel (#23)

* chore: release 24.7.0 (#15)

* fix: remove ldap stopping task (#17) (#18)

* fix: restart only enabled services (#21) (#22)

* fix: restart only enabled services



---------



* feat: remove pgpool (#24)

feat: remove pgpool

* feat: install carbonio-pflogsumm package (#26)

* feat: add carbonio-search-ui package

* feat: password checks (#32) (#33)

* feat: add password checks

* chore: 24.12.2

* feat: password checks (#32) (#34)

* feat: add password checks

* chore: 24.12.2

* feat:  install if package is missed

* feat: 25.3.0 changes (#37)

* chore: merge changes from devel (#35)

* chore: release 24.7.0 (#15)

* fix: remove ldap stopping task (#17) (#18)

* fix: restart only enabled services (#21)

* fix: restart only enabled services

* chore: 24.9.1

* chore: release 24.12.0 (#29)

* hostfix: enable possibility to upgrade ha (#30)

* hostfix: enable possibility to upgrade ha

* feat: password checks (#32) (#33)

* feat: add password checks

* chore: 24.12.2

* feat: password checks (#32) (#34)

* feat: add password checks

* chore: 24.12.2

---------



* feat: upgrade from older  versions (#36)

* chore: remove unneeded file

* feat: upgrade wsc

* chore: change names for wsc bootstrap tasks

* chore: add changelog and fix vars

* chore: stop appserver if cerbonio core version < 4.2

* chore: check carbonio-core with apt list

* chore: restart only application service

* chore: revert to carbonio-services stop

* chore: run autoremove before pending-setups

* chore: check of /etc/carbonio was created

* chore: stop carbonio maibox services

* chore: restart carbonio services before stop

* chore: added /etc/carbonio check to changelog

* chore: change changelog date

* chore: add wsc group check

---------



* chore: add wsc group check to changelog (#38)

* chore: add carbonio core checks for rhel (#40)

* chore: add carbonio core checks for rhel

* chore: added centos

* hotfix: remove search-ui upgrade/installation (#41)

* hotfix: 24.12 upgrade without dbconnectors group (#43)

* hotfix: 24.12 upgrade without dbconnectors group

* chore: 24.12 -> 25.3

* hotfix: install notification push  (#44)

* hotfix: support of notification push  and new&old  upgrade videoservers

* chore: install notification push

* chore: change syntax

* fix: fix wsc and notification push db bootstrap

* fix: fix wsc and notification push db bootstrap for RHEL

* chore: add installation of packages for wsc

* chore: reorganize changelog

* hotfix: a carbonio-perl-mailtools package to syslog group (#45)

---------